### PR TITLE
Added filter for incidentLines

### DIFF
--- a/MMM-WienerLinien.js
+++ b/MMM-WienerLinien.js
@@ -210,7 +210,7 @@ Module.register('MMM-WienerLinien', {
                 const typeIcon = document.createElement('i');
                 typeIcon.classList.add('fa', 'fa-wheelchair');
                 typeColumn.appendChild(typeIcon);
-            } else if(this.config.incidentLines.includes(this[type][i].lines)) {
+            } else if (this.config.incidentLines.includes(this[type][i].lines)) {
                 typeColumn.innerHTML = this[type][i].lines;
             }
             row.appendChild(typeColumn);
@@ -219,7 +219,7 @@ Module.register('MMM-WienerLinien', {
             description.classList.add('align-left');
             if (type === 'elevators') {
                 description.innerHTML = this[type][i];
-            } else if(this.config.incidentLines.includes(this[type][i].lines)) {
+            } else if (this.config.incidentLines.includes(this[type][i].lines)) {
                 description.innerHTML = this[type][i].description;
             }
             row.appendChild(description);

--- a/MMM-WienerLinien.js
+++ b/MMM-WienerLinien.js
@@ -210,7 +210,7 @@ Module.register('MMM-WienerLinien', {
                 const typeIcon = document.createElement('i');
                 typeIcon.classList.add('fa', 'fa-wheelchair');
                 typeColumn.appendChild(typeIcon);
-            } else {
+            } else if(this.config.incidentLines.includes(this[type][i].lines)) {
                 typeColumn.innerHTML = this[type][i].lines;
             }
             row.appendChild(typeColumn);
@@ -219,7 +219,7 @@ Module.register('MMM-WienerLinien', {
             description.classList.add('align-left');
             if (type === 'elevators') {
                 description.innerHTML = this[type][i];
-            } else {
+            } else if(this.config.incidentLines.includes(this[type][i].lines)) {
                 description.innerHTML = this[type][i].description;
             }
             row.appendChild(description);


### PR DESCRIPTION
incidentLines was - from my understanding - supposed to act as a filter for which lines to show in the Incidents section. Upon filling the variable, ALL incidents showed up unfiltered, thus cluttering the screen.
I added a filter when filling the table, so now only the lines contained in the variable are displayed.

TODO: Apparently Wiener Linien sometimes fills in two lines in one entry. This is not checked and would require manual filtering of each entry.

* Does the pull request solve an issue (add a reference)?
No
* What are the features of this pr?
Added filters for Incident section
